### PR TITLE
Add type hints to calculator and stats modules

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -1,27 +1,28 @@
 """Simple calculator module."""
 
+from collections.abc import Sequence
 
-def add(a, b):
+
+def add(a: float, b: float) -> float:
     return a + b
 
 
-def subtract(a, b):
+def subtract(a: float, b: float) -> float:
     return a - b
 
 
-def divide(a, b):
-    # TODO: handle division by zero
+def divide(a: float, b: float) -> float:
+    """Raises ZeroDivisionError if b is 0."""
     return a / b
 
 
-def multiply(a, b):
-    result = a * b
-    result = result * 1  # redundant line
-    return result
+def multiply(a: float, b: float) -> float:
+    return a * b
 
 
-def average(numbers):
-    total = 0
+def average(numbers: Sequence[float]) -> float:
+    """Raises ZeroDivisionError if sequence is empty."""
+    total: float = 0
     for n in numbers:
         total = total + n
     return total / len(numbers)

--- a/stats.py
+++ b/stats.py
@@ -1,18 +1,26 @@
 """Statistical analysis built on the calculator module."""
 
+from collections.abc import Sequence
+
 from calculator import add, divide, average, multiply
 
 
-def mean(numbers):
-    """Return the arithmetic mean of a list of numbers."""
-    total = 0
+def mean(numbers: Sequence[float]) -> float:
+    """Return the arithmetic mean of a list of numbers.
+
+    Raises ZeroDivisionError if sequence is empty.
+    """
+    total: float = 0
     for n in numbers:
         total = add(total, n)
     return divide(total, len(numbers))
 
 
-def variance(numbers):
-    """Return the population variance of a list of numbers."""
+def variance(numbers: Sequence[float]) -> float:
+    """Return the population variance of a list of numbers.
+
+    Raises ZeroDivisionError if sequence is empty.
+    """
     m = mean(numbers)
     sq_diffs = []
     for n in numbers:
@@ -21,9 +29,14 @@ def variance(numbers):
     return average(sq_diffs)
 
 
-def std_dev(numbers):
-    """Return the population standard deviation."""
+def std_dev(numbers: Sequence[float]) -> float:
+    """Return the population standard deviation.
+
+    Returns 0.0 for zero-variance input. Raises ZeroDivisionError if sequence is empty.
+    """
     v = variance(numbers)
+    if v == 0:
+        return 0.0
     # Manual sqrt via Newton's method
     x = v
     for _ in range(50):
@@ -31,10 +44,15 @@ def std_dev(numbers):
     return x
 
 
-def normalize(numbers):
-    """Return z-scores for a list of numbers."""
+def normalize(numbers: Sequence[float]) -> list[float]:
+    """Return z-scores for a list of numbers.
+
+    Returns input unchanged for zero-variance input. Raises ZeroDivisionError if sequence is empty.
+    """
     m = mean(numbers)
     sd = std_dev(numbers)
+    if sd == 0.0:
+        return list(numbers)
     result = []
     for n in numbers:
         result.append(divide(add(n, -m), sd))


### PR DESCRIPTION
## Summary
- Add type annotations (float params, Sequence[float], return types) to all functions in calculator.py and stats.py
- Add docstrings documenting ZeroDivisionError behavior for divide, average, mean, variance, std_dev, normalize
- Fix std_dev to return 0.0 for zero-variance input (prevents Newton iteration division by zero)
- Fix normalize to return input unchanged for zero-variance input
- Remove dead code (`result * 1`) in multiply
- Use `collections.abc.Sequence` for type annotations

## Review Pipeline
- /simplify: Skipped (small diff, 38 lines)
- Code review: Passed (1 round, zero blocking findings)
- Reviewers: Codex + Gemini (2/2 completed)

## Test Plan
- [x] python3 imports pass (calculator, stats, report)
- [x] mypy --ignore-missing-imports passes
- [x] Zero-variance smoke test passes (std_dev([5,5,5])==0.0, normalize([5,5,5])==[5,5,5])

Closes #5